### PR TITLE
Expose base_alloc as a pool in public API

### DIFF
--- a/include/umf/memory_pool.h
+++ b/include/umf/memory_pool.h
@@ -124,6 +124,9 @@ UMF_EXPORT size_t umfPoolMallocUsableSize(umf_memory_pool_handle_t hPool,
 ///
 UMF_EXPORT umf_result_t umfPoolFree(umf_memory_pool_handle_t hPool, void *ptr);
 
+UMF_EXPORT umf_result_t umfPoolFreeSized(umf_memory_pool_handle_t hPool,
+                                         void *ptr, size_t size);
+
 ///
 /// @brief Frees the memory space pointed by ptr if it belongs to UMF pool, does nothing otherwise.
 /// @param ptr pointer to the allocated memory

--- a/include/umf/memory_pool_ops.h
+++ b/include/umf/memory_pool_ops.h
@@ -99,7 +99,7 @@ typedef struct umf_memory_pool_ops_t {
     ///         Whether any status other than UMF_RESULT_SUCCESS can be returned
     ///         depends on the memory provider used by the \p pool.
     ///
-    umf_result_t (*free)(void *pool, void *);
+    umf_result_t (*free)(void *pool, void *, size_t size);
 
     ///
     /// @brief Retrieve \p umf_result_t representing the error of the last failed allocation

--- a/include/umf/pools/pool_base.h
+++ b/include/umf/pools/pool_base.h
@@ -1,0 +1,25 @@
+/*
+ *
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+#ifndef UMF_BASE_MEMORY_POOL_H
+#define UMF_BASE_MEMORY_POOL_H 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <umf/memory_pool_ops.h>
+
+umf_memory_pool_ops_t *umfBasePoolOps(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UMF_JEMALLOC_MEMORY_POOL_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ set(UMF_SOURCES
     provider/provider_tracking.c
     critnib/critnib.c
     pool/pool_proxy.c
+    pool/pool_base.c
 )
 
 set(UMF_SOURCES_LINUX

--- a/src/base_alloc/base_alloc.c
+++ b/src/base_alloc/base_alloc.c
@@ -196,29 +196,6 @@ void *umf_ba_alloc(umf_ba_pool_t *pool) {
     return chunk;
 }
 
-#ifndef NDEBUG
-// Checks if given pointer belongs to the pool. Should be called
-// under the lock
-static int pool_contains_pointer(umf_ba_pool_t *pool, void *ptr) {
-    char *cptr = (char *)ptr;
-    if (cptr >= pool->data &&
-        cptr < ((char *)(pool)) + pool->metadata.pool_size) {
-        return 1;
-    }
-
-    umf_ba_next_pool_t *next_pool = pool->next_pool;
-    while (next_pool) {
-        if (cptr >= next_pool->data &&
-            cptr < ((char *)(next_pool)) + pool->metadata.pool_size) {
-            return 1;
-        }
-        next_pool = next_pool->next_pool;
-    }
-
-    return 0;
-}
-#endif
-
 void umf_ba_free(umf_ba_pool_t *pool, void *ptr) {
     if (ptr == NULL) {
         return;
@@ -227,7 +204,6 @@ void umf_ba_free(umf_ba_pool_t *pool, void *ptr) {
     umf_ba_chunk_t *chunk = (umf_ba_chunk_t *)ptr;
 
     util_mutex_lock(&pool->metadata.free_lock);
-    assert(pool_contains_pointer(pool, ptr));
     chunk->next = pool->metadata.free_list;
     pool->metadata.free_list = chunk;
 #ifndef NDEBUG

--- a/src/base_alloc/base_alloc_global.c
+++ b/src/base_alloc/base_alloc_global.c
@@ -5,40 +5,96 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 */
 
-#include <assert.h>
+/* A MT-safe base allocator */
 
+#include "base_alloc_global.h"
 #include "base_alloc.h"
+#include "base_alloc_internal.h"
+#include "utils_math.h"
 
-#define SIZE_BA_POOL_CHUNK 128
+#include <stdio.h>
 
-// global base allocator used by all providers and pools
-static umf_ba_pool_t *BA_pool = NULL;
+// allocation classes need to be powers of 2
+#define ALLOCATION_CLASSES                                                     \
+    { 16, 32, 64, 128 }
+#define NUM_ALLOCATION_CLASSES 4
 
-int umf_ba_create_global(void) {
-    assert(BA_pool == NULL);
+struct base_alloc_t {
+    size_t ac_sizes[NUM_ALLOCATION_CLASSES];
+    umf_ba_pool_t *ac[NUM_ALLOCATION_CLASSES];
+    size_t smallest_ac_size_log2;
+};
 
-    BA_pool = umf_ba_create(SIZE_BA_POOL_CHUNK);
-    if (!BA_pool) {
-        return -1;
+static struct base_alloc_t BASE_ALLOC = {.ac_sizes = ALLOCATION_CLASSES};
+
+void umf_ba_create_global(void) {
+    for (int i = 0; i < NUM_ALLOCATION_CLASSES; i++) {
+        // allocation classes need to be powers of 2
+        assert(0 == (BASE_ALLOC.ac_sizes[i] & (BASE_ALLOC.ac_sizes[i] - 1)));
+        BASE_ALLOC.ac[i] = umf_ba_create(BASE_ALLOC.ac_sizes[i]);
+        if (!BASE_ALLOC.ac[i]) {
+            fprintf(stderr,
+                    "Cannot create base alloc allocation class for size: %zu\n",
+                    BASE_ALLOC.ac_sizes[i]);
+        }
     }
 
-    return 0;
+    size_t smallestSize = BASE_ALLOC.ac_sizes[0];
+    BASE_ALLOC.smallest_ac_size_log2 = log2Utils(smallestSize);
 }
 
 void umf_ba_destroy_global(void) {
-    assert(BA_pool);
-    umf_ba_destroy(BA_pool);
-    BA_pool = NULL;
+    for (int i = 0; i < NUM_ALLOCATION_CLASSES; i++) {
+        if (BASE_ALLOC.ac[i]) {
+            umf_ba_destroy(BASE_ALLOC.ac[i]);
+        }
+    }
 }
 
-umf_ba_pool_t *umf_ba_get_pool(size_t size) {
-    // TODO: a specific class-size base allocator can be returned here
-    assert(BA_pool);
-    assert(size <= SIZE_BA_POOL_CHUNK);
+// returns index of the allocation class for a give size
+static int size_to_idx(size_t size) {
+    assert(size <= BASE_ALLOC.ac_sizes[NUM_ALLOCATION_CLASSES - 1]);
 
-    if (size > SIZE_BA_POOL_CHUNK) {
-        return NULL;
+    if (size <= BASE_ALLOC.ac_sizes[0]) {
+        return 0;
     }
 
-    return BA_pool;
+    int isPowerOf2 = (0 == (size & (size - 1)));
+    int index =
+        (int)(log2Utils(size) + !isPowerOf2 - BASE_ALLOC.smallest_ac_size_log2);
+
+    assert(index >= 0);
+    assert(index < NUM_ALLOCATION_CLASSES);
+
+    return index;
+}
+
+void *umf_ba_global_alloc(size_t size) {
+    if (size > BASE_ALLOC.ac_sizes[NUM_ALLOCATION_CLASSES - 1]) {
+        return ba_os_alloc(size);
+    }
+
+    int ac_index = size_to_idx(size);
+    if (!BASE_ALLOC.ac[ac_index]) {
+        // if creating ac failed, fall back to os allocation
+        return ba_os_alloc(size);
+    }
+
+    return umf_ba_alloc(BASE_ALLOC.ac[ac_index]);
+}
+
+void umf_ba_global_free(void *ptr, size_t size) {
+    if (size > BASE_ALLOC.ac_sizes[NUM_ALLOCATION_CLASSES - 1]) {
+        ba_os_free(ptr, size);
+        return;
+    }
+
+    int ac_index = size_to_idx(size);
+    if (!BASE_ALLOC.ac[ac_index]) {
+        // if creating ac failed, memory must have been allocated by os
+        ba_os_free(ptr, size);
+        return;
+    }
+
+    umf_ba_free(BASE_ALLOC.ac[ac_index], ptr);
 }

--- a/src/base_alloc/base_alloc_global.h
+++ b/src/base_alloc/base_alloc_global.h
@@ -14,9 +14,11 @@
 extern "C" {
 #endif
 
-int umf_ba_create_global(void);
+void umf_ba_create_global(void);
 void umf_ba_destroy_global(void);
-umf_ba_pool_t *umf_ba_get_pool(size_t size);
+
+void *umf_ba_global_alloc(size_t size);
+void umf_ba_global_free(void *ptr, size_t size);
 
 #ifdef __cplusplus
 }

--- a/src/memory_pool.c
+++ b/src/memory_pool.c
@@ -60,10 +60,16 @@ size_t umfPoolMallocUsableSize(umf_memory_pool_handle_t hPool, void *ptr) {
 
 umf_result_t umfPoolFree(umf_memory_pool_handle_t hPool, void *ptr) {
     UMF_CHECK((hPool != NULL), UMF_RESULT_ERROR_INVALID_ARGUMENT);
-    return hPool->ops.free(hPool->pool_priv, ptr);
+    return hPool->ops.free(hPool->pool_priv, ptr, 0);
 }
 
 umf_result_t umfPoolGetLastAllocationError(umf_memory_pool_handle_t hPool) {
     UMF_CHECK((hPool != NULL), UMF_RESULT_ERROR_INVALID_ARGUMENT);
     return hPool->ops.get_last_allocation_error(hPool->pool_priv);
+}
+
+umf_result_t umfPoolFreeSized(umf_memory_pool_handle_t hPool, void *ptr,
+                              size_t size) {
+    UMF_CHECK((hPool != NULL), UMF_RESULT_ERROR_INVALID_ARGUMENT);
+    return hPool->ops.free(hPool->pool_priv, ptr, size);
 }

--- a/src/memory_pool_default.c
+++ b/src/memory_pool_default.c
@@ -20,7 +20,7 @@ umf_result_t umfPoolCreateInternal(const umf_memory_pool_ops_t *ops,
                                    umf_memory_provider_handle_t provider,
                                    void *params,
                                    umf_memory_pool_handle_t *hPool) {
-    if (!ops || !provider || !hPool) {
+    if (!ops || !hPool) {
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 

--- a/src/memory_pool_internal.h
+++ b/src/memory_pool_internal.h
@@ -31,9 +31,6 @@ typedef struct umf_memory_pool_t {
     umf_memory_provider_handle_t provider;
     // Tells whether memory provider is owned by the pool.
     bool own_provider;
-
-    // saved pointer to the global base allocator
-    umf_ba_pool_t *base_allocator;
 } umf_memory_pool_t;
 
 umf_result_t umfPoolCreateInternal(const umf_memory_pool_ops_t *ops,

--- a/src/memory_pool_tracking.c
+++ b/src/memory_pool_tracking.c
@@ -21,7 +21,7 @@ umf_result_t umfPoolCreateInternal(const umf_memory_pool_ops_t *ops,
                                    umf_memory_provider_handle_t provider,
                                    void *params,
                                    umf_memory_pool_handle_t *hPool) {
-    if (!ops || !provider || !hPool) {
+    if (!ops || !hPool) {
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 

--- a/src/memory_target.c
+++ b/src/memory_target.c
@@ -24,27 +24,20 @@ umf_result_t umfMemoryTargetCreate(const umf_memory_target_ops_t *ops,
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
-    umf_ba_pool_t *base_allocator =
-        umf_ba_get_pool(sizeof(umf_memory_target_t));
-    if (!base_allocator) {
-        return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-    }
-
     umf_memory_target_handle_t target =
-        (umf_memory_target_t *)umf_ba_alloc(base_allocator);
+        (umf_memory_target_t *)umf_ba_global_alloc(sizeof(umf_memory_target_t));
     if (!target) {
         return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
 
     assert(ops->version == UMF_VERSION_CURRENT);
 
-    target->base_allocator = base_allocator;
     target->ops = ops;
 
     void *target_priv;
     umf_result_t ret = ops->initialize(params, &target_priv);
     if (ret != UMF_RESULT_SUCCESS) {
-        umf_ba_free(base_allocator, target);
+        umf_ba_global_free(target, sizeof(umf_memory_target_t));
         return ret;
     }
 
@@ -58,5 +51,5 @@ umf_result_t umfMemoryTargetCreate(const umf_memory_target_ops_t *ops,
 void umfMemoryTargetDestroy(umf_memory_target_handle_t memoryTarget) {
     assert(memoryTarget);
     memoryTarget->ops->finalize(memoryTarget->priv);
-    umf_ba_free(memoryTarget->base_allocator, memoryTarget);
+    umf_ba_global_free(memoryTarget, sizeof(umf_memory_target_t));
 }

--- a/src/memory_target.h
+++ b/src/memory_target.h
@@ -24,9 +24,6 @@ typedef struct umf_memory_target_ops_t umf_memory_target_ops_t;
 typedef struct umf_memory_target_t {
     const umf_memory_target_ops_t *ops;
     void *priv;
-
-    // saved pointer to the global base allocator
-    umf_ba_pool_t *base_allocator;
 } umf_memory_target_t;
 
 typedef umf_memory_target_t *umf_memory_target_handle_t;

--- a/src/memspace.c
+++ b/src/memspace.c
@@ -12,6 +12,7 @@
 
 #include <umf/memspace.h>
 
+#include "base_alloc_global.h"
 #include "memory_target.h"
 #include "memory_target_ops.h"
 #include "memspace_internal.h"
@@ -105,5 +106,5 @@ void umfMemspaceDestroy(umf_memspace_handle_t memspace) {
     }
 
     umf_ba_linear_destroy(memspace->linear_allocator);
-    umf_ba_free(memspace->base_allocator, memspace);
+    umf_ba_global_free(memspace, sizeof(struct umf_memspace_t));
 }

--- a/src/memspace_internal.h
+++ b/src/memspace_internal.h
@@ -24,9 +24,6 @@ struct umf_memspace_t {
     size_t size;
     umf_memory_target_handle_t *nodes;
 
-    // saved pointer to the global base allocator
-    umf_ba_pool_t *base_allocator;
-
     // own local linear base allocator
     umf_ba_linear_pool_t *linear_allocator;
 };

--- a/src/memspaces/memspace_numa.c
+++ b/src/memspaces/memspace_numa.c
@@ -23,15 +23,9 @@ umfMemspaceCreateFromNumaArray(size_t *nodeIds, size_t numIds,
     }
 
     enum umf_result_t ret = UMF_RESULT_SUCCESS;
-
-    umf_ba_pool_t *base_allocator =
-        umf_ba_get_pool(sizeof(struct umf_memspace_t));
-    if (!base_allocator) {
-        return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-    }
-
     umf_memspace_handle_t memspace =
-        (struct umf_memspace_t *)umf_ba_alloc(base_allocator);
+        (struct umf_memspace_t *)umf_ba_global_alloc(
+            sizeof(struct umf_memspace_t));
     if (!memspace) {
         return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
@@ -43,7 +37,6 @@ umfMemspaceCreateFromNumaArray(size_t *nodeIds, size_t numIds,
         goto err_umf_ba_linear_create;
     }
 
-    memspace->base_allocator = base_allocator;
     memspace->linear_allocator = linear_allocator;
 
     memspace->size = numIds;
@@ -75,6 +68,6 @@ err_target_create:
 err_nodes_alloc:
     umf_ba_linear_destroy(linear_allocator);
 err_umf_ba_linear_create:
-    umf_ba_free(base_allocator, memspace);
+    umf_ba_global_free(memspace, sizeof(struct umf_memspace_t));
     return ret;
 }

--- a/src/pool/pool_base.c
+++ b/src/pool/pool_base.c
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+*/
+
+/* A MT-safe base allocator */
+
+#include "base_alloc_global.h"
+#include "base_alloc_internal.h"
+#include "utils_common.h"
+#include "utils_math.h"
+
+#include <umf/memory_pool_ops.h>
+#include <umf/pools/pool_base.h>
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// TODO: we can make this a param to the pool
+// allocation classes need to be powers of 2
+#define ALLOCATION_CLASSES                                                     \
+    { 16, 32, 64, 128 }
+#define NUM_ALLOCATION_CLASSES 4
+
+struct base_memory_pool {
+    umf_memory_provider_handle_t hProvider;
+    size_t ac_sizes[NUM_ALLOCATION_CLASSES];
+    umf_ba_pool_t *ac[NUM_ALLOCATION_CLASSES];
+    size_t smallest_ac_size_log2;
+};
+
+// returns index of the allocation class for a give size
+static int size_to_idx(struct base_memory_pool *pool, size_t size) {
+    assert(size <= pool->ac_sizes[NUM_ALLOCATION_CLASSES - 1]);
+
+    if (size <= pool->ac_sizes[0]) {
+        return 0;
+    }
+
+    int isPowerOf2 = (0 == (size & (size - 1)));
+    int index =
+        (int)(log2Utils(size) + !isPowerOf2 - pool->smallest_ac_size_log2);
+
+    assert(index >= 0);
+    assert(index < NUM_ALLOCATION_CLASSES);
+
+    return index;
+}
+
+static umf_result_t base_pool_initialize(umf_memory_provider_handle_t hProvider,
+                                         void *params, void **ppPool) {
+    (void)params; // unused
+
+    struct base_memory_pool *pool =
+        umf_ba_global_alloc(sizeof(struct base_memory_pool));
+    if (!pool) {
+        return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    *pool = (struct base_memory_pool){.ac_sizes = ALLOCATION_CLASSES};
+
+    for (int i = 0; i < NUM_ALLOCATION_CLASSES; i++) {
+        // allocation classes need to be powers of 2
+        assert(0 == (pool->ac_sizes[i] & (pool->ac_sizes[i] - 1)));
+        pool->ac[i] = umf_ba_create(pool->ac_sizes[i]);
+        if (!pool->ac[i]) {
+            fprintf(stderr,
+                    "Cannot create base alloc allocation class for size: %zu\n",
+                    pool->ac_sizes[i]);
+        }
+    }
+
+    size_t smallestSize = pool->ac_sizes[0];
+    pool->smallest_ac_size_log2 = log2Utils(smallestSize);
+
+    pool->hProvider = hProvider;
+    *ppPool = (void *)pool;
+
+    return UMF_RESULT_SUCCESS;
+}
+
+static void base_pool_finalize(void *p) {
+    struct base_memory_pool *pool = (struct base_memory_pool *)p;
+    for (int i = 0; i < NUM_ALLOCATION_CLASSES; i++) {
+        if (pool->ac[i]) {
+            umf_ba_destroy(pool->ac[i]);
+        }
+    }
+    umf_ba_global_free(pool, sizeof(struct base_memory_pool));
+}
+
+static void *base_aligned_malloc(void *p, size_t size, size_t alignment) {
+    struct base_memory_pool *pool = (struct base_memory_pool *)p;
+    assert(pool);
+
+    if (alignment > 8) {
+        return NULL;
+    }
+
+    if (size > pool->ac_sizes[NUM_ALLOCATION_CLASSES - 1] ||
+        !pool->ac[size_to_idx(pool, size)]) {
+        return ba_os_alloc(size);
+    }
+
+    return umf_ba_alloc(pool->ac[size_to_idx(pool, size)]);
+}
+
+static void *base_malloc(void *pool, size_t size) {
+    assert(pool);
+    return base_aligned_malloc(pool, size, 0);
+}
+
+static void *base_calloc(void *pool, size_t num, size_t size) {
+    assert(pool);
+    void *ptr = base_malloc(pool, num * size);
+
+    if (ptr) {
+        // TODO: memory might not be accessible on the host
+        memset(ptr, 0, num * size);
+    }
+
+    return ptr;
+}
+
+static void *base_realloc(void *pool, void *ptr, size_t size) {
+    assert(pool);
+
+    (void)pool;
+    (void)ptr;
+    (void)size;
+
+    // TODO: implement
+    return NULL;
+}
+
+static umf_result_t base_free(void *p, void *ptr, size_t size) {
+    if (!ptr) {
+        return UMF_RESULT_SUCCESS;
+    }
+
+    struct base_memory_pool *pool = (struct base_memory_pool *)p;
+    assert(pool);
+
+    if (size == 0) {
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (size > pool->ac_sizes[NUM_ALLOCATION_CLASSES - 1] ||
+        !pool->ac[size_to_idx(pool, size)]) {
+        ba_os_free(ptr, size);
+        return UMF_RESULT_SUCCESS;
+    }
+
+    umf_ba_free(pool->ac[size_to_idx(pool, size)], ptr);
+
+    return UMF_RESULT_SUCCESS;
+}
+
+static size_t base_malloc_usable_size(void *pool, void *ptr) {
+    (void)pool;
+    (void)ptr;
+    return 0;
+}
+
+static umf_result_t base_get_last_allocation_error(void *pool) {
+    (void)pool;
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+static umf_memory_pool_ops_t UMF_BASE_POOL_OPS = {
+    .version = UMF_VERSION_CURRENT,
+    .initialize = base_pool_initialize,
+    .finalize = base_pool_finalize,
+    .malloc = base_malloc,
+    .calloc = base_calloc,
+    .realloc = base_realloc,
+    .aligned_malloc = base_aligned_malloc,
+    .malloc_usable_size = base_malloc_usable_size,
+    .free = base_free,
+    .get_last_allocation_error = base_get_last_allocation_error};
+
+umf_memory_pool_ops_t *umfBasePoolOps(void) { return &UMF_BASE_POOL_OPS; }

--- a/src/pool/pool_disjoint.cpp
+++ b/src/pool/pool_disjoint.cpp
@@ -44,7 +44,7 @@ class DisjointPool {
     void *realloc(void *, size_t);
     void *aligned_malloc(size_t size, size_t alignment);
     size_t malloc_usable_size(void *);
-    umf_result_t free(void *ptr);
+    umf_result_t free(void *ptr, size_t size);
     umf_result_t get_last_allocation_error();
 
     DisjointPool();
@@ -1022,7 +1022,7 @@ size_t DisjointPool::malloc_usable_size(void *) {
     return 0;
 }
 
-umf_result_t DisjointPool::free(void *ptr) try {
+umf_result_t DisjointPool::free(void *ptr, size_t) try {
     bool ToPool;
     impl->deallocate(ptr, ToPool);
 

--- a/src/pool/pool_jemalloc.c
+++ b/src/pool/pool_jemalloc.c
@@ -24,9 +24,6 @@
 typedef struct jemalloc_memory_pool_t {
     umf_memory_provider_handle_t provider;
     unsigned int arena_index; // index of jemalloc arena
-
-    // saved pointer to the global base allocator
-    umf_ba_pool_t *base_allocator;
 } jemalloc_memory_pool_t;
 
 static __TLS umf_result_t TLS_last_allocation_error;
@@ -361,18 +358,12 @@ static umf_result_t je_initialize(umf_memory_provider_handle_t provider,
     size_t unsigned_size = sizeof(unsigned);
     int err;
 
-    umf_ba_pool_t *base_allocator =
-        umf_ba_get_pool(sizeof(jemalloc_memory_pool_t));
-    if (!base_allocator) {
-        return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-    }
-
-    jemalloc_memory_pool_t *pool = umf_ba_alloc(base_allocator);
+    jemalloc_memory_pool_t *pool =
+        umf_ba_global_alloc(sizeof(jemalloc_memory_pool_t));
     if (!pool) {
         return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
 
-    pool->base_allocator = base_allocator;
     pool->provider = provider;
 
     unsigned arena_index;
@@ -403,7 +394,7 @@ static umf_result_t je_initialize(umf_memory_provider_handle_t provider,
     return UMF_RESULT_SUCCESS;
 
 err_free_pool:
-    umf_ba_free(base_allocator, pool);
+    umf_ba_global_free(pool, sizeof(jemalloc_memory_pool_t));
     return UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC;
 }
 
@@ -414,7 +405,7 @@ static void je_finalize(void *pool) {
     snprintf(cmd, sizeof(cmd), "arena.%u.destroy", je_pool->arena_index);
     mallctl(cmd, NULL, 0, NULL, 0);
     pool_by_arena_index[je_pool->arena_index] = NULL;
-    umf_ba_free(je_pool->base_allocator, je_pool);
+    umf_ba_global_free(je_pool, sizeof(jemalloc_memory_pool_t));
 }
 
 static size_t je_malloc_usable_size(void *pool, void *ptr) {

--- a/src/pool/pool_jemalloc.c
+++ b/src/pool/pool_jemalloc.c
@@ -284,8 +284,9 @@ static void *je_malloc(void *pool, size_t size) {
     return ptr;
 }
 
-static umf_result_t je_free(void *pool, void *ptr) {
+static umf_result_t je_free(void *pool, void *ptr, size_t size) {
     (void)pool; // unused
+    (void)size;
     assert(pool);
 
     if (ptr != NULL) {

--- a/src/pool/pool_proxy.c
+++ b/src/pool/pool_proxy.c
@@ -89,7 +89,8 @@ static void *proxy_realloc(void *pool, void *ptr, size_t size) {
     return NULL;
 }
 
-static umf_result_t proxy_free(void *pool, void *ptr) {
+static umf_result_t proxy_free(void *pool, void *ptr, size_t size) {
+    (void)size;
     assert(pool);
 
     struct proxy_memory_pool *hPool = (struct proxy_memory_pool *)pool;

--- a/src/pool/pool_scalable.c
+++ b/src/pool/pool_scalable.c
@@ -55,9 +55,6 @@ struct tbb_callbacks {
 struct tbb_memory_pool {
     umf_memory_provider_handle_t mem_provider;
     void *tbb_pool;
-
-    // saved pointer to the global base allocator
-    umf_ba_pool_t *base_allocator;
 };
 
 static struct tbb_callbacks g_tbb_ops;
@@ -150,19 +147,13 @@ static umf_result_t tbb_pool_initialize(umf_memory_provider_handle_t provider,
         return UMF_RESULT_ERROR_UNKNOWN;
     }
 
-    umf_ba_pool_t *base_allocator =
-        umf_ba_get_pool(sizeof(struct tbb_memory_pool));
-    if (!base_allocator) {
-        return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-    }
-
-    struct tbb_memory_pool *pool_data = umf_ba_alloc(base_allocator);
+    struct tbb_memory_pool *pool_data =
+        umf_ba_global_alloc(sizeof(struct tbb_memory_pool));
     if (!pool_data) {
         fprintf(stderr, "cannot allocate memory for metadata\n");
         return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
 
-    pool_data->base_allocator = base_allocator;
     pool_data->mem_provider = provider;
     int ret = g_tbb_ops.pool_create_v1((intptr_t)pool_data, &policy,
                                        &(pool_data->tbb_pool));
@@ -179,7 +170,7 @@ static void tbb_pool_finalize(void *pool) {
     pthread_once(&tbb_is_initialized, load_tbb_symbols);
     struct tbb_memory_pool *pool_data = (struct tbb_memory_pool *)pool;
     g_tbb_ops.pool_destroy(pool_data->tbb_pool);
-    umf_ba_free(pool_data->base_allocator, pool_data);
+    umf_ba_global_free(pool_data, sizeof(struct tbb_memory_pool));
 }
 
 static void *tbb_malloc(void *pool, size_t size) {

--- a/src/pool/pool_scalable.c
+++ b/src/pool/pool_scalable.c
@@ -229,7 +229,8 @@ static void *tbb_aligned_malloc(void *pool, size_t size, size_t alignment) {
     return ptr;
 }
 
-static umf_result_t tbb_free(void *pool, void *ptr) {
+static umf_result_t tbb_free(void *pool, void *ptr, size_t size) {
+    (void)size;
     if (ptr == NULL) {
         return UMF_RESULT_SUCCESS;
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -125,3 +125,9 @@ add_umf_test(NAME base_alloc
 add_umf_test(NAME base_alloc_linear
             SRCS ${BA_SOURCES_FOR_TEST} test_base_alloc_linear.cpp
             LIBS umf_utils)
+if(LINUX)
+    # TODO: fix this on windows
+    add_umf_test(NAME base_alloc_global
+                SRCS ${BA_SOURCES_FOR_TEST} pools/pool_base_alloc.cpp malloc_compliance_tests.cpp
+                LIBS umf_utils)
+endif()

--- a/test/common/pool.hpp
+++ b/test/common/pool.hpp
@@ -82,6 +82,22 @@ bool isCallocSupported(umf_memory_pool_handle_t hPool) {
     return supported;
 }
 
+bool isAlignedAllocSupported(umf_memory_pool_handle_t hPool) {
+    static constexpr size_t allocSize = 8;
+    static constexpr size_t alignment = 8;
+    auto *ptr = umfPoolAlignedMalloc(hPool, allocSize, alignment);
+
+    if (ptr) {
+        umfPoolFree(hPool, ptr);
+        return true;
+    } else if (umfPoolGetLastAllocationError(hPool) ==
+               UMF_RESULT_ERROR_NOT_SUPPORTED) {
+        return false;
+    } else {
+        throw std::runtime_error("AlignedMalloc failed with unexpected error");
+    }
+}
+
 typedef struct pool_base_t {
     umf_result_t initialize(umf_memory_provider_handle_t) noexcept {
         return UMF_RESULT_SUCCESS;

--- a/test/common/pool.hpp
+++ b/test/common/pool.hpp
@@ -107,7 +107,7 @@ typedef struct pool_base_t {
     void *realloc(void *, size_t) noexcept { return nullptr; }
     void *aligned_malloc(size_t, size_t) noexcept { return nullptr; }
     size_t malloc_usable_size(void *) noexcept { return 0; }
-    umf_result_t free(void *) noexcept { return UMF_RESULT_SUCCESS; }
+    umf_result_t free(void *, size_t) noexcept { return UMF_RESULT_SUCCESS; }
     umf_result_t get_last_allocation_error() noexcept {
         return UMF_RESULT_SUCCESS;
     }
@@ -138,7 +138,7 @@ struct malloc_pool : public pool_base_t {
         return ::malloc_usable_size(ptr);
 #endif
     }
-    umf_result_t free(void *ptr) noexcept {
+    umf_result_t free(void *ptr, size_t) noexcept {
         ::free(ptr);
         return UMF_RESULT_SUCCESS;
     }

--- a/test/common/pool_null.c
+++ b/test/common/pool_null.c
@@ -52,9 +52,10 @@ static size_t nullMallocUsableSize(void *pool, void *ptr) {
     return 0;
 }
 
-static umf_result_t nullFree(void *pool, void *ptr) {
+static umf_result_t nullFree(void *pool, void *ptr, size_t size) {
     (void)pool;
     (void)ptr;
+    (void)size;
     return UMF_RESULT_SUCCESS;
 }
 

--- a/test/common/pool_trace.c
+++ b/test/common/pool_trace.c
@@ -73,7 +73,8 @@ static size_t traceMallocUsableSize(void *pool, void *ptr) {
     return umfPoolMallocUsableSize(trace_pool->params.hUpstreamPool, ptr);
 }
 
-static umf_result_t traceFree(void *pool, void *ptr) {
+static umf_result_t traceFree(void *pool, void *ptr, size_t size) {
+    (void)size;
     trace_pool_t *trace_pool = (trace_pool_t *)pool;
 
     trace_pool->params.trace("free");

--- a/test/common/provider.hpp
+++ b/test/common/provider.hpp
@@ -63,6 +63,9 @@ typedef struct provider_base_t {
     const char *get_name() noexcept { return "base"; }
 } provider_base_t;
 
+umf_memory_provider_ops_t BASE_PROVIDER_OPS =
+    umf::providerMakeCOps<provider_base_t, void>();
+
 struct provider_malloc : public provider_base_t {
     umf_result_t alloc(size_t size, size_t align, void **ptr) noexcept {
         if (!align) {

--- a/test/memoryPoolAPI.cpp
+++ b/test/memoryPoolAPI.cpp
@@ -183,12 +183,6 @@ TEST_P(umfPoolWithCreateFlagsTest, umfPoolCreateFlagsNullPoolHandle) {
     umfMemoryProviderDestroy(provider);
 }
 
-TEST_P(umfPoolWithCreateFlagsTest, umfPoolCreateFlagsInvalidProviders) {
-    umf_memory_pool_handle_t hPool;
-    auto ret = umfPoolCreate(&MALLOC_POOL_OPS, nullptr, nullptr, flags, &hPool);
-    ASSERT_EQ(ret, UMF_RESULT_ERROR_INVALID_ARGUMENT);
-}
-
 struct poolInitializeTest : umf_test::test,
                             ::testing::WithParamInterface<umf_result_t> {};
 

--- a/test/poolFixtures.hpp
+++ b/test/poolFixtures.hpp
@@ -136,6 +136,9 @@ TEST_P(umfPoolTest, callocFree) {
 }
 
 void pow2AlignedAllocHelper(umf_memory_pool_handle_t pool) {
+    if (!umf_test::isAlignedAllocSupported(pool)) {
+        GTEST_SKIP();
+    }
     static constexpr size_t maxAlignment = (1u << 22);
     static constexpr size_t numAllocs = 4;
     for (size_t alignment = 1; alignment <= maxAlignment; alignment <<= 1) {

--- a/test/pools/pool_base_alloc.cpp
+++ b/test/pools/pool_base_alloc.cpp
@@ -1,0 +1,65 @@
+// Copyright (C) 2023 Intel Corporation
+// Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <unordered_map>
+
+#include "umf/pools/pool_scalable.h"
+#include "umf/providers/provider_os_memory.h"
+
+#include "pool.hpp"
+#include "poolFixtures.hpp"
+#include "provider.hpp"
+
+#include "base_alloc_global.h"
+
+struct base_alloc_pool : public umf_test::pool_base_t {
+    std::unordered_map<void *, size_t> sizes;
+    std::mutex m;
+
+    void *malloc(size_t size) noexcept {
+        auto *ptr = umf_ba_global_alloc(size);
+        std::unique_lock<std::mutex> l(m);
+        sizes[ptr] = size;
+        return ptr;
+    }
+    void *calloc(size_t, size_t) noexcept {
+        umf::getPoolLastStatusRef<base_alloc_pool>() =
+            UMF_RESULT_ERROR_NOT_SUPPORTED;
+        return NULL;
+    }
+    void *realloc(void *, size_t) noexcept {
+        umf::getPoolLastStatusRef<base_alloc_pool>() =
+            UMF_RESULT_ERROR_NOT_SUPPORTED;
+        return NULL;
+    }
+    void *aligned_malloc(size_t, size_t) noexcept {
+        umf::getPoolLastStatusRef<base_alloc_pool>() =
+            UMF_RESULT_ERROR_NOT_SUPPORTED;
+        return NULL;
+    }
+    size_t malloc_usable_size(void *ptr) noexcept {
+        std::unique_lock<std::mutex> l(m);
+        return sizes[ptr];
+    }
+    umf_result_t free(void *ptr) noexcept {
+        size_t size;
+        {
+            std::unique_lock<std::mutex> l(m);
+            size = sizes[ptr];
+        }
+
+        umf_ba_global_free(ptr, size);
+        return UMF_RESULT_SUCCESS;
+    }
+    umf_result_t get_last_allocation_error() {
+        return umf::getPoolLastStatusRef<base_alloc_pool>();
+    }
+};
+
+umf_memory_pool_ops_t BA_POOL_OPS = umf::poolMakeCOps<base_alloc_pool, void>();
+
+INSTANTIATE_TEST_SUITE_P(baPool, umfPoolTest,
+                         ::testing::Values(poolCreateExtParams{
+                             &BA_POOL_OPS, nullptr,
+                             &umf_test::BASE_PROVIDER_OPS, nullptr}));


### PR DESCRIPTION
Expose base_alloc as a pool in public API. It can be used by users to allocate metadata for their providers/pools.
The core libumf (libumf.so/.a) accesses the pool API through umf_ba_global_alloc/free functions for allocating umf_memory_pool_t, umf_memory_provider_t etc. to avoid infinite recursion. There is no recursion problem in external libs.